### PR TITLE
Fix fog in 1.17

### DIFF
--- a/shaders/gbuffers_basic.fsh
+++ b/shaders/gbuffers_basic.fsh
@@ -24,8 +24,7 @@ void main()
     vec4 col = color;
 
     //Calculate fog intensity in or out of water.
-    float fog = (isEyeInWater>0) ? 1.-exp(-gl_FogFragCoord * gl_Fog.density):
-    clamp((gl_FogFragCoord-gl_Fog.start) * gl_Fog.scale, 0., 1.);
+    float fog = clamp((gl_FogFragCoord-gl_Fog.start) * gl_Fog.scale, 0., 1.);
 
     //Apply the fog.
     col.rgb = mix(col.rgb, gl_Fog.color.rgb, fog);

--- a/shaders/gbuffers_basic.fsh
+++ b/shaders/gbuffers_basic.fsh
@@ -19,12 +19,25 @@ uniform int isEyeInWater;
 //Vertex color.
 varying vec4 color;
 
+const int GL_LINEAR = 9729;
+const int GL_EXP = 2048;
+uniform int fogMode;
+
 void main()
 {
     vec4 col = color;
 
+
     //Calculate fog intensity in or out of water.
-    float fog = clamp((gl_FogFragCoord-gl_Fog.start) * gl_Fog.scale, 0., 1.);
+    float fog;
+    if(fogMode == GL_EXP)
+        fog = 1.-exp(-gl_FogFragCoord * gl_Fog.density);
+    else if (fogMode == GL_LINEAR)
+        fog = clamp((gl_FogFragCoord-gl_Fog.start) * gl_Fog.scale, 0., 1.);
+    else if (isEyeInWater == 1.0 || isEyeInWater == 2.0)
+        fog = 1.-exp(-gl_FogFragCoord * gl_Fog.density);
+
+    //float fog = clamp((gl_FogFragCoord-gl_Fog.start) * gl_Fog.scale, 0., 1.);
 
     //Apply the fog.
     col.rgb = mix(col.rgb, gl_Fog.color.rgb, fog);

--- a/shaders/gbuffers_clouds.fsh
+++ b/shaders/gbuffers_clouds.fsh
@@ -24,6 +24,10 @@ varying vec4 color;
 //Diffuse texture coordinates.
 varying vec2 coord0;
 
+const int GL_LINEAR = 9729;
+const int GL_EXP = 2048;
+uniform int fogMode;
+
 void main()
 {
     //Visibility amount.
@@ -32,7 +36,15 @@ void main()
     vec4 col = color * vec4(light,1) * texture2D(texture,coord0);
 
     //Calculate fog intensity in or out of water.
-    float fog = clamp((gl_FogFragCoord-gl_Fog.start) * gl_Fog.scale, 0., 1.);
+    float fog;
+    if(fogMode == GL_EXP)
+        fog = 1.-exp(-gl_FogFragCoord * gl_Fog.density);
+    else if (fogMode == GL_LINEAR)
+        fog = clamp((gl_FogFragCoord-gl_Fog.start) * gl_Fog.scale, 0., 1.);
+    else if (isEyeInWater == 1.0 || isEyeInWater == 2.0)
+        fog = 1.-exp(-gl_FogFragCoord * gl_Fog.density);
+
+    //float fog = clamp((gl_FogFragCoord-gl_Fog.start) * gl_Fog.scale, 0., 1.);
 
     //Apply the fog.
     col.rgb = mix(col.rgb, gl_Fog.color.rgb, fog);

--- a/shaders/gbuffers_clouds.fsh
+++ b/shaders/gbuffers_clouds.fsh
@@ -32,8 +32,7 @@ void main()
     vec4 col = color * vec4(light,1) * texture2D(texture,coord0);
 
     //Calculate fog intensity in or out of water.
-    float fog = (isEyeInWater>0) ? 1.-exp(-gl_FogFragCoord * gl_Fog.density):
-    clamp((gl_FogFragCoord-gl_Fog.start) * gl_Fog.scale, 0., 1.);
+    float fog = clamp((gl_FogFragCoord-gl_Fog.start) * gl_Fog.scale, 0., 1.);
 
     //Apply the fog.
     col.rgb = mix(col.rgb, gl_Fog.color.rgb, fog);

--- a/shaders/gbuffers_textured.fsh
+++ b/shaders/gbuffers_textured.fsh
@@ -29,6 +29,10 @@ varying vec4 color;
 varying vec2 coord0;
 varying vec2 coord1;
 
+const int GL_LINEAR = 9729;
+const int GL_EXP = 2048;
+uniform int fogMode;
+
 void main()
 {
     //Combine lightmap with blindness.
@@ -39,7 +43,15 @@ void main()
     col.rgb = mix(col.rgb,entityColor.rgb,entityColor.a);
 
     //Calculate fog intensity in or out of water.
-    float fog = clamp((gl_FogFragCoord-gl_Fog.start) * gl_Fog.scale, 0., 1.);
+    float fog;
+    if(fogMode == GL_EXP)
+        fog = 1.-exp(-gl_FogFragCoord * gl_Fog.density);
+    else if (fogMode == GL_LINEAR)
+        fog = clamp((gl_FogFragCoord-gl_Fog.start) * gl_Fog.scale, 0., 1.);
+    else if (isEyeInWater == 1.0 || isEyeInWater == 2.0)
+        fog = 1.-exp(-gl_FogFragCoord * gl_Fog.density);
+
+    //float fog = clamp((gl_FogFragCoord-gl_Fog.start) * gl_Fog.scale, 0., 1.);
 
     //Apply the fog.
     col.rgb = mix(col.rgb, gl_Fog.color.rgb, fog);

--- a/shaders/gbuffers_textured.fsh
+++ b/shaders/gbuffers_textured.fsh
@@ -39,8 +39,7 @@ void main()
     col.rgb = mix(col.rgb,entityColor.rgb,entityColor.a);
 
     //Calculate fog intensity in or out of water.
-    float fog = (isEyeInWater>0) ? 1.-exp(-gl_FogFragCoord * gl_Fog.density):
-    clamp((gl_FogFragCoord-gl_Fog.start) * gl_Fog.scale, 0., 1.);
+    float fog = clamp((gl_FogFragCoord-gl_Fog.start) * gl_Fog.scale, 0., 1.);
 
     //Apply the fog.
     col.rgb = mix(col.rgb, gl_Fog.color.rgb, fog);


### PR DESCRIPTION
This is a very crude fix and not perfectly accurate, but it works well. This fixes compatibility with Iris on versions above 1.17, while maintaining compatibility with versions below 1.17.

Nether still has problems with fog on Iris:
![image](https://user-images.githubusercontent.com/15901769/131759711-9fb35a68-acd4-45fe-9b3e-be77957ac41e.png)
Black beyond unloaded chunks, seems that fog isn't being applied to the skybox in the nether.